### PR TITLE
Fix UI image view layout with framezilla

### DIFF
--- a/Sources/ElementType.swift
+++ b/Sources/ElementType.swift
@@ -119,6 +119,24 @@ public class ViewType: ElementType {
         }
     }
 
+    override var frame: CGRect {
+        get {
+            view.frame
+        }
+        set {
+            view.frame = newValue
+        }
+    }
+
+    override var bounds: CGRect {
+        get {
+            view.bounds
+        }
+        set {
+            view.bounds = newValue
+        }
+    }
+
     var safeAreaInsets: UIEdgeInsets {
         if #available(iOS 11.0, *) {
             return view.safeAreaInsets


### PR DESCRIPTION
Broken in Layers support
Reason: `configureFrame` sets frame on view layer by default. Overriding `frame` for ViewType fixes the problem